### PR TITLE
Use linkify-it instead of custom regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,23 +69,8 @@ _default:_ `{}`
 
 NOTE: Use `Linkify.MATCH` as a value to specify the matched link. The properties prop will always contain `{href: Linkify.MATCH, key: 'LINKIFY_KEY_#'}` unless overridden.
 
-**urlRegex**  
-The regular expression used to identify url links.  
-_type:_ `object`  
-_default:_ `/\b(?:(?:https):\/\/|[-A-Z0-9+&@#/%=~_|$?!:,.]+\.)(?:\([-A-Z0-9+&@#/%=~_|$?!:,.]*\)|[-A-Z0-9+&@#/%=~_|$?!:,.])*(?:\([-A-Z0-9+&@#/%=~_|$?!:,.]*\)|[A-Z0-9+&@#/%=~_|$])/i`
+## Examples
 
-**emailRegex**  
-The regular expression used to identify email links.  
-_type:_ `object`  
-_default:_ `/\b[-A-Z0-9+&%=~_|$!.]+@[-A-Z0-9+&%=~_|$!.]+\.[-A-Z0-9+&%=~_|$!]+/i`
-
-Some of the cases the default regex handles (link inside code block):
-- `github.com`
-- `www.google.com`
-- `http://www.zakarie.com`
-- `https://www.facebook.com`
-- "`www.google.com:8080`"
-- `http://en.wikipedia.org/wiki/React_(JavaScript_library)`
-- Examples are available at `http://tasti.github.io/react-linkify/`.
-- `tasti@zakarie.com`
-- For more information, contact `tasti@zakarie.com`.
+All kind of links detectable by
+[linkify-it](https://github.com/markdown-it/linkify-it) are supported. For
+examples, visit [their website](http://markdown-it.github.io/linkify-it/).

--- a/dist/Linkify.js
+++ b/dist/Linkify.js
@@ -6,104 +6,100 @@ Object.defineProperty(exports, '__esModule', {
 
 var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; desc = parent = getter = undefined; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; continue _function; } } else if ('value' in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
-function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
+function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _linkifyIt = require('linkify-it');
+
+var _linkifyIt2 = _interopRequireDefault(_linkifyIt);
+
+var _tlds = require('tlds');
+
+var _tlds2 = _interopRequireDefault(_tlds);
+
+var linkify = new _linkifyIt2['default']();
+linkify.tlds(_tlds2['default']);
+
 var Linkify = (function (_React$Component) {
+  _inherits(Linkify, _React$Component);
+
   function Linkify() {
     _classCallCheck(this, Linkify);
 
-    if (_React$Component != null) {
-      _React$Component.apply(this, arguments);
-    }
-
-    this.matchings = [{ type: 'email', regex: this.props.emailRegex }, { type: 'url', regex: this.props.urlRegex }];
+    _get(Object.getPrototypeOf(Linkify.prototype), 'constructor', this).apply(this, arguments);
   }
 
-  _inherits(Linkify, _React$Component);
-
   _createClass(Linkify, [{
-    key: 'getMatch',
-    value: function getMatch(string) {
-      for (var i = 0; i < this.matchings.length; ++i) {
-        var matching = this.matchings[i];
-        var idx = string.search(matching.regex);
-
-        if (idx !== -1) {
-          var str = string.match(matching.regex)[0];
-
-          return {
-            str: str,
-            type: matching.type,
-            idx: idx,
-            len: str.length
-          };
-        }
-      }
-
-      return false;
-    }
-  }, {
-    key: 'formatLink',
-    value: function formatLink(match) {
-      if (match.type === 'email') {
-        return 'mailto:' + match.str;
-      } else if (match.type === 'url') {
-        if (match.str.substring(0, 4).toLowerCase() === 'http') {
-          return match.str;
-        } else {
-          return 'http://' + match.str;
-        }
-      }
-
-      return match.str;
-    }
-  }, {
-    key: 'parseStringHelper',
-    value: function parseStringHelper(string, elements) {
-      if (string === '') {
-        return elements;
-      }
-
-      var match = this.getMatch(string);
-      if (!match) {
-        elements.push(string);
-        return this.parseStringHelper('', elements);
-      }
-
-      // Push the preceding text if there is any
-      if (match.idx > 0) {
-        elements.push(string.substring(0, match.idx));
-      }
-
-      // Shallow update values that specified the match
-      var props = { href: this.formatLink(match), key: Linkify.uniqueKey() };
-      for (var key in this.props.properties) {
-        var val = this.props.properties[key];
-        if (val === Linkify.MATCH) {
-          val = this.formatLink(match);
-        }
-
-        props[key] = val;
-      }
-
-      elements.push(_react2['default'].createElement(this.props.component, props, match.str));
-
-      return this.parseStringHelper(string.substring(match.idx + match.len), elements);
+    key: 'getMatches',
+    value: function getMatches(string) {
+      return linkify.match(string);
     }
   }, {
     key: 'parseString',
     value: function parseString(string) {
       var elements = [];
+      if (string === '') {
+        return elements;
+      }
 
-      this.parseStringHelper(string, elements);
+      var matches = this.getMatches(string);
+      if (!matches) {
+        return string;
+      }
+
+      var lastIndex = 0;
+      var _iteratorNormalCompletion = true;
+      var _didIteratorError = false;
+      var _iteratorError = undefined;
+
+      try {
+        for (var _iterator = matches[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+          var match = _step.value;
+
+          // Push the preceding text if there is any
+          if (match.index > lastIndex) {
+            elements.push(string.substring(lastIndex, match.index));
+          }
+          // Shallow update values that specified the match
+          var props = { href: match.url, key: Linkify.uniqueKey() };
+          for (var key in this.props.properties) {
+            var val = this.props.properties[key];
+            if (val === Linkify.MATCH) {
+              val = match.url;
+            }
+
+            props[key] = val;
+          }
+          elements.push(_react2['default'].createElement(this.props.component, props, match.text));
+          lastIndex = match.lastIndex;
+        }
+      } catch (err) {
+        _didIteratorError = true;
+        _iteratorError = err;
+      } finally {
+        try {
+          if (!_iteratorNormalCompletion && _iterator['return']) {
+            _iterator['return']();
+          }
+        } finally {
+          if (_didIteratorError) {
+            throw _iteratorError;
+          }
+        }
+      }
+
+      if (lastIndex !== string) {
+        elements.push(string.substring(lastIndex));
+      }
 
       return elements.length === 1 ? elements[0] : elements;
     }
@@ -138,6 +134,11 @@ var Linkify = (function (_React$Component) {
       );
     }
   }], [{
+    key: 'uniqueKey',
+    value: function uniqueKey() {
+      return 'LINKIFY_KEY_' + ++Linkify.keyCounter;
+    }
+  }, {
     key: 'MATCH',
     value: 'LINKIFY_MATCH',
     enumerable: true
@@ -145,11 +146,6 @@ var Linkify = (function (_React$Component) {
     key: 'keyCounter',
     value: 0,
     enumerable: true
-  }, {
-    key: 'uniqueKey',
-    value: function uniqueKey() {
-      return 'LINKIFY_KEY_' + ++Linkify.keyCounter;
-    }
   }, {
     key: 'propTypes',
     value: {
@@ -163,10 +159,7 @@ var Linkify = (function (_React$Component) {
     key: 'defaultProps',
     value: {
       component: 'a',
-      properties: {},
-      // TODO: Improve regexs
-      urlRegex: /\b(?:(?:https):\/\/|[-A-Z0-9+&@#/%=~_|$?!:,.]+\.)(?:\([-A-Z0-9+&@#/%=~_|$?!:,.]*\)|[-A-Z0-9+&@#/%=~_|$?!:,.])*(?:\([-A-Z0-9+&@#/%=~_|$?!:,.]*\)|[A-Z0-9+&@#/%=~_|$])/i,
-      emailRegex: /\b[-A-Z0-9+&%=~_|$!.]+@[-A-Z0-9+&%=~_|$!.]+\.[-A-Z0-9+&%=~_|$!]+/i
+      properties: {}
     },
     enumerable: true
   }]);
@@ -176,5 +169,3 @@ var Linkify = (function (_React$Component) {
 
 exports['default'] = Linkify;
 module.exports = exports['default'];
-
-// In order of precedence, for when regexs overlap

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "babel-jest": "~5.2.0",
+    "jest": "^0.1.40",
     "jest-cli": "~0.4.5",
     "react": "~0.13.3",
     "react-tools": "~0.13.3"
@@ -37,5 +38,9 @@
       "<rootDir>/node_modules/react"
     ],
     "scriptPreprocessor": "<rootDir>/node_modules/babel-jest"
+  },
+  "dependencies": {
+    "linkify-it": "^1.2.0",
+    "tlds": "^1.57.0"
   }
 }


### PR DESCRIPTION
The library is more reliable way of detecting links and fixes some of the
edge cases old regexes were failing at. For example:

- node.js is not an url.
- e.g. is not an url
- unicode links
- only links in valid TLDs are detected.

Fix #6, fix #4