### PR TITLE
use temporary counters to stay isomorphic friendly

### DIFF
--- a/src/Linkify.jsx
+++ b/src/Linkify.jsx
@@ -8,11 +8,6 @@ linkify.tlds(tlds);
 class Linkify extends React.Component {
   static MATCH = 'LINKIFY_MATCH'
 
-  static keyCounter = 0
-  static uniqueKey() {
-    return `LINKIFY_KEY_${++Linkify.keyCounter}`;
-  }
-
   static propTypes = {
     component: React.PropTypes.any,
     properties: React.PropTypes.object,
@@ -24,6 +19,8 @@ class Linkify extends React.Component {
     component: 'a',
     properties: {},
   }
+
+  parseCounter = 0
 
   getMatches(string) {
     return linkify.match(string);
@@ -41,13 +38,14 @@ class Linkify extends React.Component {
     }
 
     let lastIndex = 0;
+    let idx = 0;
     for (let match of matches) {
       // Push the preceding text if there is any
       if (match.index > lastIndex) {
         elements.push(string.substring(lastIndex, match.index));
       }
       // Shallow update values that specified the match
-      let props = {href: match.url, key: Linkify.uniqueKey()};
+      let props = {href: match.url, key: `match${++idx}`};
       for (let key in this.props.properties) {
         let val = this.props.properties[key];
         if (val === Linkify.MATCH) {
@@ -79,7 +77,7 @@ class Linkify extends React.Component {
     } else if (React.isValidElement(children) && (children.type !== 'a') && (children.type !== 'button')) {
       parsed = React.cloneElement(
         children,
-        {key: Linkify.uniqueKey()},
+        {key: `parse${++this.parseCounter}`},
         this.parse(children.props.children)
       );
     } else if (children instanceof Array) {
@@ -92,6 +90,7 @@ class Linkify extends React.Component {
   }
 
   render() {
+    this.parseCounter = 0;
     const parsedChildren = this.parse(this.props.children);
 
     return <span className="Linkify">{parsedChildren}</span>;


### PR DESCRIPTION
there's a separate counter for "matches" and a separate for parsed-out elements.
this leads to reproducible numbers, no matter how many times the code is run, which is exactly a requirement for isomorphic code