### PR TITLE
Fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+sudo: false
+language: node_js
+node_js:
+  - node
+  - "4.2"

--- a/package.json
+++ b/package.json
@@ -27,16 +27,13 @@
     "test": "BABEL_JEST_STAGE=0 jest"
   },
   "devDependencies": {
-    "babel-jest": "~5.2.0",
+    "babel-jest": "~5.3.0",
     "jest": "^0.1.40",
-    "jest-cli": "~0.4.5",
+    "jest-cli": "~0.7.1",
     "react": "~0.13.3",
     "react-tools": "~0.13.3"
   },
   "jest": {
-    "unmockedModulePathPatterns": [
-      "<rootDir>/node_modules/react"
-    ],
     "scriptPreprocessor": "<rootDir>/node_modules/babel-jest"
   },
   "dependencies": {

--- a/src/Linkify.jsx
+++ b/src/Linkify.jsx
@@ -62,7 +62,7 @@ class Linkify extends React.Component {
       lastIndex = match.lastIndex;
     }
 
-    if (lastIndex !== string) {
+    if (lastIndex < string.length) {
       elements.push(string.substring(lastIndex));
     }
 

--- a/src/__tests__/Linkify-test.js
+++ b/src/__tests__/Linkify-test.js
@@ -1,11 +1,11 @@
-jest.dontMock('../Linkify.jsx');
+jest.autoMockOff();
 
 let React = require('react/addons');
 let TestUtils = React.addons.TestUtils;
 
 describe('Linkify', () => {
   let Linkify = require('../Linkify.jsx');
-  
+
   describe('#parseString', () => {
     let linkify = TestUtils.renderIntoDocument(<Linkify></Linkify>);
 
@@ -80,7 +80,7 @@ describe('Linkify', () => {
 
   describe('#parse', () => {
     let linkify = TestUtils.renderIntoDocument(<Linkify></Linkify>);
-    
+
     it('should not parse <a> elements', () => {
       let input = (
         <a href="http://facebook.github.io/react/">
@@ -122,7 +122,7 @@ describe('Linkify', () => {
   });
 
   describe('#render', () => {
-  
+
   });
 
   describe('#static', () => {


### PR DESCRIPTION
The tests were failing.
I turned of automocking, as it does not make sense in this case as we want the dependencies (linkify-it, tlds) to work.

And in the parseString() method there was an invalid comparison. Should obvious if you look at the change in Linkify.jsx. We were comparing the string to the lastIndex instead of the string.length.

I also added a config file for travis, so would be nice if you could turn it on.