### PR TITLE
Remove use of for..of

### DIFF
--- a/src/Linkify.jsx
+++ b/src/Linkify.jsx
@@ -38,14 +38,13 @@ class Linkify extends React.Component {
     }
 
     let lastIndex = 0;
-    let idx = 0;
-    for (let match of matches) {
+    matches.forEach((match, idx) => {
       // Push the preceding text if there is any
       if (match.index > lastIndex) {
         elements.push(string.substring(lastIndex, match.index));
       }
       // Shallow update values that specified the match
-      let props = {href: match.url, key: `parse${this.parseCounter}match${++idx}`};
+      let props = {href: match.url, key: `parse${this.parseCounter}match${idx}`};
       for (let key in this.props.properties) {
         let val = this.props.properties[key];
         if (val === Linkify.MATCH) {
@@ -60,7 +59,7 @@ class Linkify extends React.Component {
         match.text
       ));
       lastIndex = match.lastIndex;
-    }
+    });
 
     if (lastIndex < string.length) {
       elements.push(string.substring(lastIndex));


### PR DESCRIPTION
As mentioned in [babel docs](https://babeljs.io/docs/learn-es2015/), use of `for..of` requires support for Symbol.iterator (or a polyfill for it). Since `for..of` is used only once in the code, I find it easier to use more traditional looping instead of setting up polyfills for it.

Related issue: https://github.com/tasti/react-linkify/issues/8