### PR TITLE
Fix not to overwrite a tags by giving unique keys

### DIFF
--- a/src/Linkify.jsx
+++ b/src/Linkify.jsx
@@ -45,7 +45,7 @@ class Linkify extends React.Component {
         elements.push(string.substring(lastIndex, match.index));
       }
       // Shallow update values that specified the match
-      let props = {href: match.url, key: `match${++idx}`};
+      let props = {href: match.url, key: `parse${this.parseCounter}match${++idx}`};
       for (let key in this.props.properties) {
         let val = this.props.properties[key];
         if (val === Linkify.MATCH) {


### PR DESCRIPTION
If you have multiple a tags, only the first a tag was displayed and the rest were gone because it gave the same react key to these tags.
Fix not to give the same key by adding parseCounter to it.