### PR TITLE
Add Support for custom span className

### DIFF
--- a/dist/Linkify.js
+++ b/dist/Linkify.js
@@ -1,16 +1,10 @@
 'use strict';
 
-Object.defineProperty(exports, '__esModule', {
+Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _react = require('react');
 
@@ -24,21 +18,33 @@ var _tlds = require('tlds');
 
 var _tlds2 = _interopRequireDefault(_tlds);
 
-var linkify = new _linkifyIt2['default']();
-linkify.tlds(_tlds2['default']);
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var Linkify = (function (_React$Component) {
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var linkify = new _linkifyIt2.default();
+linkify.tlds(_tlds2.default);
+
+var Linkify = function (_React$Component) {
+  _inherits(Linkify, _React$Component);
+
   function Linkify() {
+    var _Object$getPrototypeO;
+
+    var _temp, _this, _ret;
+
     _classCallCheck(this, Linkify);
 
-    if (_React$Component != null) {
-      _React$Component.apply(this, arguments);
+    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+      args[_key] = arguments[_key];
     }
 
-    this.parseCounter = 0;
+    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_Object$getPrototypeO = Object.getPrototypeOf(Linkify)).call.apply(_Object$getPrototypeO, [this].concat(args))), _this), _this.parseCounter = 0, _temp), _possibleConstructorReturn(_this, _ret);
   }
-
-  _inherits(Linkify, _React$Component);
 
   _createClass(Linkify, [{
     key: 'getMatches',
@@ -48,6 +54,8 @@ var Linkify = (function (_React$Component) {
   }, {
     key: 'parseString',
     value: function parseString(string) {
+      var _this2 = this;
+
       var elements = [];
       if (string === '') {
         return elements;
@@ -59,46 +67,24 @@ var Linkify = (function (_React$Component) {
       }
 
       var lastIndex = 0;
-      var idx = 0;
-      var _iteratorNormalCompletion = true;
-      var _didIteratorError = false;
-      var _iteratorError = undefined;
-
-      try {
-        for (var _iterator = matches[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-          var match = _step.value;
-
-          // Push the preceding text if there is any
-          if (match.index > lastIndex) {
-            elements.push(string.substring(lastIndex, match.index));
-          }
-          // Shallow update values that specified the match
-          var props = { href: match.url, key: 'match' + ++idx };
-          for (var key in this.props.properties) {
-            var val = this.props.properties[key];
-            if (val === Linkify.MATCH) {
-              val = match.url;
-            }
-
-            props[key] = val;
-          }
-          elements.push(_react2['default'].createElement(this.props.component, props, match.text));
-          lastIndex = match.lastIndex;
+      matches.forEach(function (match, idx) {
+        // Push the preceding text if there is any
+        if (match.index > lastIndex) {
+          elements.push(string.substring(lastIndex, match.index));
         }
-      } catch (err) {
-        _didIteratorError = true;
-        _iteratorError = err;
-      } finally {
-        try {
-          if (!_iteratorNormalCompletion && _iterator['return']) {
-            _iterator['return']();
+        // Shallow update values that specified the match
+        var props = { href: match.url, key: 'parse' + _this2.parseCounter + 'match' + idx };
+        for (var key in _this2.props.properties) {
+          var val = _this2.props.properties[key];
+          if (val === Linkify.MATCH) {
+            val = match.url;
           }
-        } finally {
-          if (_didIteratorError) {
-            throw _iteratorError;
-          }
+
+          props[key] = val;
         }
-      }
+        elements.push(_react2.default.createElement(_this2.props.component, props, match.text));
+        lastIndex = match.lastIndex;
+      });
 
       if (lastIndex < string.length) {
         elements.push(string.substring(lastIndex));
@@ -109,17 +95,17 @@ var Linkify = (function (_React$Component) {
   }, {
     key: 'parse',
     value: function parse(children) {
-      var _this = this;
+      var _this3 = this;
 
       var parsed = children;
 
       if (typeof children === 'string') {
         parsed = this.parseString(children);
-      } else if (_react2['default'].isValidElement(children) && children.type !== 'a' && children.type !== 'button') {
-        parsed = _react2['default'].cloneElement(children, { key: 'parse' + ++this.parseCounter }, this.parse(children.props.children));
+      } else if (_react2.default.isValidElement(children) && children.type !== 'a' && children.type !== 'button') {
+        parsed = _react2.default.cloneElement(children, { key: 'parse' + ++this.parseCounter }, this.parse(children.props.children));
       } else if (children instanceof Array) {
         parsed = children.map(function (child) {
-          return _this.parse(child);
+          return _this3.parse(child);
         });
       }
 
@@ -131,35 +117,28 @@ var Linkify = (function (_React$Component) {
       this.parseCounter = 0;
       var parsedChildren = this.parse(this.props.children);
 
-      return _react2['default'].createElement(
+      return _react2.default.createElement(
         'span',
-        { className: 'Linkify' },
+        { className: this.props.className },
         parsedChildren
       );
     }
-  }], [{
-    key: 'MATCH',
-    value: 'LINKIFY_MATCH',
-    enumerable: true
-  }, {
-    key: 'propTypes',
-    value: {
-      component: _react2['default'].PropTypes.any,
-      properties: _react2['default'].PropTypes.object,
-      urlRegex: _react2['default'].PropTypes.object,
-      emailRegex: _react2['default'].PropTypes.object
-    },
-    enumerable: true
-  }, {
-    key: 'defaultProps',
-    value: {
-      component: 'a',
-      properties: {} },
-    enumerable: true
   }]);
 
   return Linkify;
-})(_react2['default'].Component);
+}(_react2.default.Component);
 
-exports['default'] = Linkify;
-module.exports = exports['default'];
+Linkify.MATCH = 'LINKIFY_MATCH';
+Linkify.propTypes = {
+  className: _react2.default.PropTypes.string,
+  component: _react2.default.PropTypes.any,
+  properties: _react2.default.PropTypes.object,
+  urlRegex: _react2.default.PropTypes.object,
+  emailRegex: _react2.default.PropTypes.object
+};
+Linkify.defaultProps = {
+  className: 'Linkify',
+  component: 'a',
+  properties: {}
+};
+exports.default = Linkify;

--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
   },
   "devDependencies": {
     "babel-cli": "^6.7.7",
-    "babel-jest": "~5.3.0",
+    "babel-jest": "^12.1.0",
     "babel-plugin-transform-react-jsx": "^6.7.5",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-0": "^6.5.0",
-    "jest": "^0.1.40",
-    "jest-cli": "~0.7.1",
+    "jest": "^12.1.1",
+    "jest-cli": "^12.1.1",
     "react-addons-test-utils": "~0.14.2"
   },
   "jest": {

--- a/src/Linkify.jsx
+++ b/src/Linkify.jsx
@@ -9,6 +9,7 @@ class Linkify extends React.Component {
   static MATCH = 'LINKIFY_MATCH'
 
   static propTypes = {
+    className: React.PropTypes.string,
     component: React.PropTypes.any,
     properties: React.PropTypes.object,
     urlRegex: React.PropTypes.object,
@@ -16,6 +17,7 @@ class Linkify extends React.Component {
   }
 
   static defaultProps = {
+    className: 'Linkify',
     component: 'a',
     properties: {},
   }
@@ -92,7 +94,7 @@ class Linkify extends React.Component {
     this.parseCounter = 0;
     const parsedChildren = this.parse(this.props.children);
 
-    return <span className="Linkify">{parsedChildren}</span>;
+    return <span className={this.props.className}>{parsedChildren}</span>;
   }
 }
 

--- a/src/__tests__/Linkify-test.js
+++ b/src/__tests__/Linkify-test.js
@@ -122,7 +122,17 @@ describe('Linkify', () => {
   });
 
   describe('#render', () => {
+    let linkify = TestUtils.renderIntoDocument(<Linkify></Linkify>);
 
+    it('should render with default className of Linkify if one is not provided', () => {
+      expect(linkify.props.className).toEqual('Linkify');
+    });
+
+    it('should render with a custom className if one is provided', () => {
+      let linkify = TestUtils.renderIntoDocument(<Linkify className="custom-class"></Linkify>);
+
+      expect(linkify.props.className).toEqual('custom-class');
+    });
   });
 
   describe('#static', () => {

--- a/src/__tests__/Linkify-test.js
+++ b/src/__tests__/Linkify-test.js
@@ -4,7 +4,7 @@ let React = require('react');
 let TestUtils = require('react-addons-test-utils');
 
 describe('Linkify', () => {
-  let Linkify = require('../Linkify.jsx');
+  let Linkify = require('../Linkify.jsx').default;
 
   describe('#parseString', () => {
     let linkify = TestUtils.renderIntoDocument(<Linkify></Linkify>);


### PR DESCRIPTION
Add support for passing in a custom className as prop to the wrapping span. Default the prop to Linkify to avoid breaking anyone that is depending on the Linkify class that is currently hard-coded.

I had to also update jest, babel-jest, and jest-cli to get the tests to run. Left as a separate commit in case it is a problem.