### PR TITLE
Support custom rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ If you're feeling lazy, you can wrap `Linkify` around anywhere that you want lin
 
 Renders to:
 
-react-linkify (`tasti.github.io/react-linkify/`)  
-React component to parse links (urls, emails, etc.) in text into clickable links  
-See examples at `tasti.github.io/react-linkify/`.  
+react-linkify (`tasti.github.io/react-linkify/`)
+React component to parse links (urls, emails, etc.) in text into clickable links
+See examples at `tasti.github.io/react-linkify/`.
 Contact: `tasti@zakarie.com`
 
 
@@ -57,17 +57,37 @@ React.render(
 
 ## Props
 
-**component**  
-The type of component to wrap links in.  
-_type:_ `any`  
-_default:_ `'a'`  
+**component**
+The type of component to wrap links in.
+_type:_ `any`
+_default:_ `'a'`
 
-**properties**  
-The props that will be added to every matched component.  
-_type:_ `object`  
+**properties**
+The props that will be added to every matched component.
+_type:_ `object`
 _default:_ `{}`
 
 NOTE: Use `Linkify.MATCH` as a value to specify the matched link. The properties prop will always contain `{href: Linkify.MATCH, key: 'LINKIFY_KEY_#'}` unless overridden.
+
+**handlers**
+Handlers to match custom link types, like Twitter @mentions.
+
+_type_:
+```js
+arrayOf(
+    shape({
+        prefix: string.isRequired,
+        validate: func.isRequired,
+        normalize: func.isRequired
+    })
+)
+```
+_default:_ `[]`
+
+See the [example mentions handler](https://github.com/markdown-it/linkify-it#example-2-add-twitter-mentions-handler) from linkify-it for more details.
+
+## Customization
+Custom handlers can be added to a specific `Linkify` instance with the `handlers` prop. Additionally, the singleton linkify-it instance can be imported (`import { linkify } from 'react-linkify'`) for global customization. See the [linkify-it api docs](http://markdown-it.github.io/linkify-it/doc/)
 
 ## Examples
 

--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
   },
   "devDependencies": {
     "babel-cli": "^6.7.7",
-    "babel-jest": "~5.3.0",
+    "babel-jest": "^12.1.0",
     "babel-plugin-transform-react-jsx": "^6.7.5",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-0": "^6.5.0",
-    "jest": "^0.1.40",
-    "jest-cli": "~0.7.1",
+    "jest": "^12.1.1",
+    "jest-cli": "^12.1.1",
     "react-addons-test-utils": "~0.14.2"
   },
   "jest": {

--- a/src/Linkify.jsx
+++ b/src/Linkify.jsx
@@ -29,32 +29,37 @@ class Linkify extends React.Component {
   }
 
   componentDidMount() {
-    this.addCustomHandlers()
+    this.addCustomHandlers();
   }
 
   componentDidUpdate(nextProps) {
     if (this.props.handlers !== nextProps.handlers) {
-      this.addCustomHandlers()
+      this.addCustomHandlers();
     }
   }
 
   addCustomHandlers() {
-    const { handlers } = this.props
+    const { handlers } = this.props;
 
     if (handlers.length) {
+      this.linkify = new LinkifyIt();
+      this.linkify.tlds(tlds);
+
       handlers.forEach(handler => {
-        linkify.add(handler.prefix, {
+        this.linkify.add(handler.prefix, {
           validate: handler.validate,
           normalize: handler.normalize
-        })
-      })
+        });
+      });
     }
   }
 
   parseCounter = 0
 
   getMatches(string) {
-    return linkify.match(string);
+    const linkifyInstance = this.linkify || linkify;
+
+    return linkifyInstance.match(string);
   }
 
   parseString(string) {

--- a/src/Linkify.jsx
+++ b/src/Linkify.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import LinkifyIt from 'linkify-it';
 import tlds from 'tlds';
 
-const linkify = new LinkifyIt();
+export const linkify = new LinkifyIt();
 linkify.tlds(tlds);
 
 class Linkify extends React.Component {
@@ -12,12 +12,43 @@ class Linkify extends React.Component {
     component: React.PropTypes.any,
     properties: React.PropTypes.object,
     urlRegex: React.PropTypes.object,
-    emailRegex: React.PropTypes.object
+    emailRegex: React.PropTypes.object,
+    handlers: React.PropTypes.arrayOf(
+      React.PropTypes.shape({
+        prefix: React.PropTypes.string,
+        validate: React.PropTypes.func,
+        normalize: React.PropTypes.func
+      })
+    )
   }
 
   static defaultProps = {
     component: 'a',
     properties: {},
+    handlers: []
+  }
+
+  componentDidMount() {
+    this.addCustomHandlers()
+  }
+
+  componentDidUpdate(nextProps) {
+    if (this.props.handlers !== nextProps.handlers) {
+      this.addCustomHandlers()
+    }
+  }
+
+  addCustomHandlers() {
+    const { handlers } = this.props
+
+    if (handlers.length) {
+      handlers.forEach(handler => {
+        linkify.add(handler.prefix, {
+          validate: handler.validate,
+          normalize: handler.normalize
+        })
+      })
+    }
   }
 
   parseCounter = 0

--- a/src/Linkify.jsx
+++ b/src/Linkify.jsx
@@ -15,9 +15,9 @@ class Linkify extends React.Component {
     emailRegex: React.PropTypes.object,
     handlers: React.PropTypes.arrayOf(
       React.PropTypes.shape({
-        prefix: React.PropTypes.string,
-        validate: React.PropTypes.func,
-        normalize: React.PropTypes.func
+        prefix: React.PropTypes.string.isRequired,
+        validate: React.PropTypes.func.isRequired,
+        normalize: React.PropTypes.func.isRequired
       })
     )
   }

--- a/src/__tests__/Linkify-test.js
+++ b/src/__tests__/Linkify-test.js
@@ -122,7 +122,7 @@ describe('Linkify', () => {
   });
 
   describe('#addCustomHandlers', () => {
-    it('should match all custom handlers added through the "handlers" prop', () => {
+    it('should match a custom handler added through the "handlers" prop', () => {
       const linkify = TestUtils.renderIntoDocument(
         <Linkify handlers={[{
           prefix: '@',
@@ -145,6 +145,44 @@ describe('Linkify', () => {
       expect(output[1].props.href).toEqual(`https://twitter.com/mention`);
       expect(output[1].props.children).toEqual(input[1]);
       expect(output[2]).toEqual(input[2]);
+    });
+
+    it('should match multiple custom handlers', () => {
+      const linkify = TestUtils.renderIntoDocument(
+        <Linkify handlers={[{
+          prefix: '@',
+          validate() {
+            return 7;
+          },
+          normalize(match) {
+            match.url = 'https://twitter.com/' + match.url.replace(/^@/, '');
+          }
+        }, {
+          prefix: '$',
+          validate() {
+            return 7;
+          },
+          normalize(match) {
+            match.url = 'https://blingtwitter.com/' + match.url.replace(/^\$/, '');
+          }
+        }]}
+        >
+        </Linkify>
+      );
+
+      const input = ['this is an ', '@mention', ' and ', '$mention', ' handler'];
+      const output = linkify.parseString(input.join(''));
+
+      expect(output[0]).toEqual(input[0]);
+      expect(output[1].type).toEqual('a');
+      expect(output[1].props.href).toEqual(`https://twitter.com/mention`);
+      expect(output[1].props.children).toEqual(input[1]);
+
+      expect(output[2]).toEqual(input[2]);
+      expect(output[3].type).toEqual('a');
+      expect(output[3].props.href).toEqual(`https://blingtwitter.com/mention`);
+      expect(output[3].props.children).toEqual(input[3]);
+      expect(output[4]).toEqual(input[4]);
     })
   });
 

--- a/src/__tests__/Linkify-test.js
+++ b/src/__tests__/Linkify-test.js
@@ -4,7 +4,7 @@ let React = require('react');
 let TestUtils = require('react-addons-test-utils');
 
 describe('Linkify', () => {
-  let Linkify = require('../Linkify.jsx');
+  let Linkify = require('../Linkify.jsx').default;
 
   describe('#parseString', () => {
     let linkify = TestUtils.renderIntoDocument(<Linkify></Linkify>);

--- a/src/__tests__/Linkify-test.js
+++ b/src/__tests__/Linkify-test.js
@@ -121,6 +121,33 @@ describe('Linkify', () => {
     });
   });
 
+  describe('#addCustomHandlers', () => {
+    it('should match all custom handlers added through the "handlers" prop', () => {
+      const linkify = TestUtils.renderIntoDocument(
+        <Linkify handlers={[{
+          prefix: '@',
+          validate() {
+            return 7;
+          },
+          normalize(match) {
+            match.url = 'https://twitter.com/' + match.url.replace(/^@/, '');
+          }
+        }]}
+        >
+        </Linkify>
+      );
+
+      const input = ['this is an ', '@mention', ' handler'];
+      const output = linkify.parseString(input.join(''));
+
+      expect(output[0]).toEqual(input[0]);
+      expect(output[1].type).toEqual('a');
+      expect(output[1].props.href).toEqual(`https://twitter.com/mention`);
+      expect(output[1].props.children).toEqual(input[1]);
+      expect(output[2]).toEqual(input[2]);
+    })
+  });
+
   describe('#render', () => {
 
   });

--- a/src/__tests__/Linkify-test.js
+++ b/src/__tests__/Linkify-test.js
@@ -5,6 +5,8 @@ let TestUtils = require('react-addons-test-utils');
 
 describe('Linkify', () => {
   let Linkify = require('../Linkify.jsx').default;
+  let linkifyCustomizations = require('../Linkify.jsx').config;
+
 
   describe('#parseString', () => {
     let linkify = TestUtils.renderIntoDocument(<Linkify></Linkify>);
@@ -121,7 +123,7 @@ describe('Linkify', () => {
     });
   });
 
-  describe('#addCustomHandlers', () => {
+  describe('LinkifyIt config', () => {
     it('should match a custom handler added through the "handlers" prop', () => {
       const linkify = TestUtils.renderIntoDocument(
         <Linkify handlers={[{
@@ -183,6 +185,109 @@ describe('Linkify', () => {
       expect(output[3].props.href).toEqual(`https://blingtwitter.com/mention`);
       expect(output[3].props.children).toEqual(input[3]);
       expect(output[4]).toEqual(input[4]);
+    })
+
+    it('should apply global customizations', () => {
+      linkifyCustomizations
+          .resetAll()
+          .tlds('linkify', true)
+          .add('@', {
+            validate() {
+              return 7;
+            },
+            normalize(match) {
+              match.url = 'https://twitter.com/' + match.url.replace(/^@/, '');
+            }
+          })
+      const linkify = TestUtils.renderIntoDocument(
+          <Linkify />
+      );
+
+      const input = ['this is an ', '@mention', ' and ', 'test.linkify', ' TLD handler'];
+      const output = linkify.parseString(input.join(''));
+
+      expect(output[0]).toEqual(input[0]);
+      expect(output[1].type).toEqual('a');
+      expect(output[1].props.href).toEqual(`https://twitter.com/mention`);
+      expect(output[1].props.children).toEqual(input[1]);
+
+      expect(output[2]).toEqual(input[2]);
+      expect(output[3].type).toEqual('a');
+      expect(output[3].props.href).toEqual(`http://test.linkify`);
+      expect(output[3].props.children).toEqual(input[3]);
+      expect(output[4]).toEqual(input[4]);
+    });
+
+    it('should merge global and instance handlers', () => {
+      linkifyCustomizations
+          .resetAll()
+          .add('@', {
+            validate() {
+              return 7;
+            },
+            normalize(match) {
+              match.url = 'https://twitter.com/' + match.url.replace(/^@/, '');
+            }
+          })
+      const linkify = TestUtils.renderIntoDocument(
+          <Linkify handlers={[{
+              prefix: '$',
+              validate() {
+                return 7;
+              },
+              normalize(match) {
+                match.url = 'https://blingtwitter.com/' + match.url.replace(/^\$/, '');
+              }
+            }]}
+          >
+          </Linkify>
+      );
+
+      const input = ['this is an ', '@mention', ' and ', '$mention', ' handler'];
+      const output = linkify.parseString(input.join(''));
+
+      expect(output[0]).toEqual(input[0]);
+      expect(output[1].type).toEqual('a');
+      expect(output[1].props.href).toEqual(`https://twitter.com/mention`);
+      expect(output[1].props.children).toEqual(input[1]);
+
+      expect(output[2]).toEqual(input[2]);
+      expect(output[3].type).toEqual('a');
+      expect(output[3].props.href).toEqual(`https://blingtwitter.com/mention`);
+      expect(output[3].props.children).toEqual(input[3]);
+      expect(output[4]).toEqual(input[4]);
+    });
+
+    it('should set fuzzy* options', () => {
+      const linkify = TestUtils.renderIntoDocument(
+          <Linkify fuzzyLink={ false } />
+      );
+
+      const linkInput = 'this should not match: www.test.com';
+      const linkOutput = linkify.parseString(linkInput);
+      expect(linkOutput).toEqual(linkInput);
+    });
+
+    it('should reset global customizations', () => {
+      linkifyCustomizations
+          .add('@', {
+            validate() {
+              return 7;
+            },
+            normalize(match) {
+              match.url = 'https://twitter.com/' + match.url.replace(/^@/, '');
+            }
+          })
+          .resetAll()
+
+      const linkify = TestUtils.renderIntoDocument(
+          <Linkify />
+      );
+
+      const input = 'this @mention should not match';
+      const output = linkify.parseString(input);
+
+      expect(output).toEqual(input);
     })
   });
 


### PR DESCRIPTION
This gives the ability to add custom linkify-it handlers to individual react-linkify instances through the `handlers` prop. Additionally, i exposed the linkify-it singleton to enable global customization.

I also cherry-picked the test-suite updates from #19.

Fixes #10 
