### PR TITLE
Added support for href decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ The props that will be added to every matched component.
 _type:_ `object`  
 _default:_ `{}`
 
+**hrefDecorator**  
+Optional function that takes matched URL and returns string to use as `href`  
+_type:_ `function`
+
 NOTE: Use `Linkify.MATCH` as a value to specify the matched link. The properties prop will always contain `{href: Linkify.MATCH, key: 'LINKIFY_KEY_#'}` unless overridden.
 
 ## Examples

--- a/dist/Linkify.js
+++ b/dist/Linkify.js
@@ -74,6 +74,9 @@ var Linkify = function (_React$Component) {
         }
         // Shallow update values that specified the match
         var props = { href: match.url, key: 'parse' + _this2.parseCounter + 'match' + idx };
+        if (_this2.props.hrefDecorator) {
+          props.href = _this2.props.hrefDecorator(match.url);
+        }
         for (var key in _this2.props.properties) {
           var val = _this2.props.properties[key];
           if (val === Linkify.MATCH) {
@@ -134,7 +137,8 @@ Linkify.propTypes = {
   component: _react2.default.PropTypes.any,
   properties: _react2.default.PropTypes.object,
   urlRegex: _react2.default.PropTypes.object,
-  emailRegex: _react2.default.PropTypes.object
+  emailRegex: _react2.default.PropTypes.object,
+  hrefDecorator: _react2.default.PropTypes.func
 };
 Linkify.defaultProps = {
   className: 'Linkify',

--- a/src/Linkify.jsx
+++ b/src/Linkify.jsx
@@ -13,7 +13,8 @@ class Linkify extends React.Component {
     component: React.PropTypes.any,
     properties: React.PropTypes.object,
     urlRegex: React.PropTypes.object,
-    emailRegex: React.PropTypes.object
+    emailRegex: React.PropTypes.object,
+    hrefDecorator: React.PropTypes.func
   }
 
   static defaultProps = {
@@ -47,6 +48,9 @@ class Linkify extends React.Component {
       }
       // Shallow update values that specified the match
       let props = {href: match.url, key: `parse${this.parseCounter}match${idx}`};
+      if (this.props.hrefDecorator) {
+        props.href = this.props.hrefDecorator(match.url);
+      }
       for (let key in this.props.properties) {
         let val = this.props.properties[key];
         if (val === Linkify.MATCH) {

--- a/src/__tests__/Linkify-test.js
+++ b/src/__tests__/Linkify-test.js
@@ -119,6 +119,17 @@ describe('Linkify', () => {
       expect(output[1].props.children).toEqual(input[1]);
       expect(output[2]).toEqual(input[2]);
     });
+
+    it('should decorate parsed href if hrefDecorator is provided', () => {
+      const exampleHrefDecorator = url => `decorated/${url}`;
+      const input = 'http://dev.null';
+      let linkify = TestUtils.renderIntoDocument(<Linkify hrefDecorator={exampleHrefDecorator}></Linkify>);
+      let output = linkify.parseString(input);
+
+      expect(output.type).toEqual('a');
+      expect(output.props.href).toEqual(`decorated/${input}`);
+      expect(output.props.children).toEqual(input);
+    });
   });
 
   describe('#render', () => {


### PR DESCRIPTION
Hi, I needed the possibility to decorate the `href` in resulting links so I added it in a very simple way (`hrefDecorator` function passed as prop). Don't know how many people will need this but might be useful for things like link forwarding, changing domains etc. 
I'm using it to pass user-generated links through a simple forwarding service which validates them and takes care of `window.opener` exploit.
