### PR TITLE
Move react back as a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "babel-preset-stage-0": "^6.5.0",
     "jest": "^12.1.1",
     "jest-cli": "^12.1.1",
+    "react": "~0.14.2",
     "react-addons-test-utils": "~0.14.2"
   },
   "jest": {
@@ -41,7 +42,6 @@
   },
   "dependencies": {
     "linkify-it": "^1.2.0",
-    "react": "~0.14.2",
     "tlds": "^1.57.0"
   }
 }


### PR DESCRIPTION
Having it as a dependency pulls in react 0.14 even if using a newer react version. In our example we use React 15 and don't want an additional react :)

This was introduced by #17 and regressed in 0.1.2

/cc @chikathreesix 
