### PR TITLE
Export LinkifyIt instance to allow customisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ _default:_ `{}`
 
 NOTE: Use `Linkify.MATCH` as a value to specify the matched link. The properties prop will always contain `{href: Linkify.MATCH, key: 'LINKIFY_KEY_#'}` unless overridden.
 
+
+## Customization
+
+You can access to the global `Linkify` instance used to linkify contents by importing it (`import { linkify } from 'react-linkify'`).
+That way you can customize as needed (e.g. disabling existing schemas or adding new ones).
+
+Note that any customization made to that instance will affect every `Linkify` component you use.
+
 ## Examples
 
 All kind of links detectable by

--- a/src/Linkify.jsx
+++ b/src/Linkify.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import LinkifyIt from 'linkify-it';
 import tlds from 'tlds';
 
-const linkify = new LinkifyIt();
+export const linkify = new LinkifyIt();
 linkify.tlds(tlds);
 
 class Linkify extends React.Component {


### PR DESCRIPTION
This is a simple change that allows users to leverage `linkify` features that are not accessible right now. In particular, adding and removing schemas.

This change brings flexibility to the component and adds almost no complexity. Users can reuse their knowledge of the `linkify` library.

I think it is a better idea to give access to the `linkify` instance and "automagically" support any change or new feature that they do instead of passing through options as stated on #20, that IMHO, will overcomplicate the component.