### PR TITLE
used 'prop-types' package

### DIFF
--- a/dist/Linkify.js
+++ b/dist/Linkify.js
@@ -19,6 +19,10 @@ var _tlds = require('tlds');
 
 var _tlds2 = _interopRequireDefault(_tlds);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -131,11 +135,11 @@ var Linkify = function (_React$Component) {
 
 Linkify.MATCH = 'LINKIFY_MATCH';
 Linkify.propTypes = {
-  className: _react2.default.PropTypes.string,
-  component: _react2.default.PropTypes.any,
-  properties: _react2.default.PropTypes.object,
-  urlRegex: _react2.default.PropTypes.object,
-  emailRegex: _react2.default.PropTypes.object
+  className: _propTypes2.default.string,
+  component: _propTypes2.default.any,
+  properties: _propTypes2.default.object,
+  urlRegex: _propTypes2.default.object,
+  emailRegex: _propTypes2.default.object
 };
 Linkify.defaultProps = {
   className: 'Linkify',

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "linkify-it": "^1.2.0",
+    "prop-types": "^15.5.8",
     "tlds": "^1.57.0"
   }
 }

--- a/src/Linkify.jsx
+++ b/src/Linkify.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import LinkifyIt from 'linkify-it';
 import tlds from 'tlds';
+import PropTypes from 'prop-types';
 
 export const linkify = new LinkifyIt();
 linkify.tlds(tlds);
@@ -9,11 +10,11 @@ class Linkify extends React.Component {
   static MATCH = 'LINKIFY_MATCH'
 
   static propTypes = {
-    className: React.PropTypes.string,
-    component: React.PropTypes.any,
-    properties: React.PropTypes.object,
-    urlRegex: React.PropTypes.object,
-    emailRegex: React.PropTypes.object
+    className: PropTypes.string,
+    component: PropTypes.any,
+    properties: PropTypes.object,
+    urlRegex: PropTypes.object,
+    emailRegex: PropTypes.object
   }
 
   static defaultProps = {


### PR DESCRIPTION
Deprecation Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.