### PR TITLE
Linkify elements using dangerouslySetInnerHTML

### DIFF
--- a/src/Linkify.jsx
+++ b/src/Linkify.jsx
@@ -77,11 +77,27 @@ class Linkify extends React.Component {
     if (typeof children === 'string') {
       parsed = this.parseString(children);
     } else if (React.isValidElement(children) && (children.type !== 'a') && (children.type !== 'button')) {
-      parsed = React.cloneElement(
-        children,
-        {key: `parse${++this.parseCounter}`},
-        this.parse(children.props.children)
-      );
+      if (children.props.children === undefined && children.props.dangerouslySetInnerHTML) {
+        const clonedProps = {};
+        
+        for ( const prop in children.props ) {
+          if(prop !== 'dangerouslySetInnerHTML') {
+            clonedProps[prop] = children.prop[prop];
+          }
+        }
+        
+        parsed = React.createElement(
+          children.type,
+          Object.assign(clonedProps, {key: `parse${++this.parseCounter}`}),
+          this.parse(children.props.dangerouslySetInnerHTML.__html)
+        );
+      } else {
+        parsed = React.cloneElement(
+          children,
+          {key: `parse${++this.parseCounter}`},
+          this.parse(children.props.children)
+        );
+      }
     } else if (children instanceof Array) {
       parsed = children.map(child => {
         return this.parse(child);

--- a/src/__tests__/Linkify-test.js
+++ b/src/__tests__/Linkify-test.js
@@ -92,6 +92,15 @@ describe('Linkify', () => {
       expect(output).toEqual(input);
     });
 
+    it('should parse elements with dangerouslySetInnerHTML', () => {
+      let input = (
+        <div dangerouslySetInnerHTML={{ __html: "http://facebook.github.io/react/"}}/>
+      );
+      let output = linkify.parse(input);
+
+      expect(output).toMatchSnapshot();
+    });
+
     it('should not parse <button> elements', () => {
       let input = <button>http://facebook.github.io/react/</button>;
       let output = linkify.parse(input);

--- a/src/__tests__/__snapshots__/Linkify-test.js.snap
+++ b/src/__tests__/__snapshots__/Linkify-test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Linkify #parse should parse elements with dangerouslySetInnerHTML 1`] = `
+<div>
+  <a
+    href="http://facebook.github.io/react/"
+  >
+    http://facebook.github.io/react/
+  </a>
+</div>
+`;


### PR DESCRIPTION
Sometimes we have a pure HTML text to parse and the links are not inside the <a> tags. On these cases, we want to render the HTML using dangerouslySetInnerHTML and linkify the content.
Example:
```
<Linkify>
  <div>Take a look on the link: https://github.com/tasti/react-linkify</div>
  <div dangerouslySetInnerHTML={{ __html: '<div>Take a look on the link https://github.com/tasti/react-linkify</div>' }} />
</Linkify>
```

Please take a look on the Codesandbox example: https://codesandbox.io/s/DRlyjgNL6

On this example, the first div is correctly linkified but not the second. This PR tries to fix that.

Depends on #44 