### PR TITLE
New tab prop

### DIFF
--- a/src/Linkify.jsx
+++ b/src/Linkify.jsx
@@ -47,6 +47,9 @@ class Linkify extends React.Component {
       }
       // Shallow update values that specified the match
       let props = {href: match.url, key: `parse${this.parseCounter}match${idx}`};
+
+      // Open link in new tab, if specified.
+      if (this.props.newTab) props.target = '_blank';
       for (let key in this.props.properties) {
         let val = this.props.properties[key];
         if (val === Linkify.MATCH) {

--- a/src/Linkify.jsx
+++ b/src/Linkify.jsx
@@ -11,10 +11,9 @@ class Linkify extends React.Component {
 
   static propTypes = {
     className: PropTypes.string,
+    newTab: PropTypes.bool,
     component: PropTypes.any,
     properties: PropTypes.object,
-    urlRegex: PropTypes.object,
-    emailRegex: PropTypes.object
   }
 
   static defaultProps = {

--- a/src/Linkify.jsx
+++ b/src/Linkify.jsx
@@ -18,6 +18,7 @@ class Linkify extends React.Component {
 
   static defaultProps = {
     className: 'Linkify',
+    newTab: false,
     component: 'a',
     properties: {},
   }

--- a/src/__tests__/Linkify-test.js
+++ b/src/__tests__/Linkify-test.js
@@ -133,6 +133,23 @@ describe('Linkify', () => {
 
       expect(linkify.props.className).toEqual('custom-class');
     });
+
+    it('should not render target attribute if newTab is not provided', () => {
+      const linkify = TestUtils.renderIntoDocument(<Linkify>'https://github.com/facebook/react'</Linkify>);
+      const anchor = TestUtils.findRenderedDOMComponentWithTag(linkify, 'a');
+
+      expect(linkify.props.newTab).toEqual(false);
+      expect(anchor.getAttribute('target')).not.toBe('_blank');
+      expect(anchor.getAttribute('target')).toBeFalsy();
+    });
+
+    it('should render target: _blank  if newTab is provided', () => {
+      const linkify = TestUtils.renderIntoDocument(<Linkify newTab>'https://github.com/facebook/react'</Linkify>);
+      const anchor = TestUtils.findRenderedDOMComponentWithTag(linkify, 'a');
+
+      expect(linkify.props.newTab).toEqual(true);
+      expect(anchor.getAttribute('target')).toEqual('_blank');
+    });
   });
 
   describe('#static', () => {


### PR DESCRIPTION
Per the discussion on Issue #48, I have added a `newTab` boolean prop that, if provided, will set `target: _blank` on matched URLs.

I added unit tests for the positive and negative cases, but I would LOVE feedback - this style of React is a bit different from what I'm used to writing 😃  